### PR TITLE
Zaimplementowano dodawanie pol typu enum

### DIFF
--- a/src/DB-Editor/Components/MainWindow/States/RecordsListing/RecordsListingPresenter.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RecordsListing/RecordsListingPresenter.cs
@@ -45,6 +45,7 @@ namespace DB_Editor.Components.MainWindow.States.RecordsListing
             StateChangeRequestEventArgs args = new StateChangeRequestEventArgs("RowEditor");
             args.Data = GetSelectedRecordData();
             args.Data["tableName"] = TableName;
+            args.Data["changeRow"] = "changeRow";
 
             return args;
         }
@@ -90,7 +91,7 @@ namespace DB_Editor.Components.MainWindow.States.RecordsListing
         public Dictionary<string, string> GetSelectedRecordData()
         {
             var output = new Dictionary<string, string>();
-
+          
             for (int i = 0; i < TableFieldNames.Count; i++)
             {
                 string fieldName = TableFieldNames.ElementAt(i);

--- a/src/DB-Editor/Components/MainWindow/States/RecordsListing/RecordsListingView.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RecordsListing/RecordsListingView.cs
@@ -38,7 +38,7 @@ namespace DB_Editor.Components.MainWindow.States.RecordsListing
             {
                 if (value.Data.ContainsKey("id"))
                 {
-                    presenter_.TableName = value.Data["id"];
+                    presenter_.TableName = value.Data["id"];               
                     presenter_.Init();
                     SetTitle(presenter_.TableName);
                 }

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.Designer.cs
@@ -1,0 +1,57 @@
+﻿namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    partial class HorizontalLineControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.HorLine = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // HorLine
+            // 
+            this.HorLine.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.HorLine.Location = new System.Drawing.Point(0, 0);
+            this.HorLine.Name = "HorLine";
+            this.HorLine.Size = new System.Drawing.Size(2, 64);
+            this.HorLine.TabIndex = 0;
+            // 
+            // HorizontalLineControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.HorLine);
+            this.Name = "HorizontalLineControl";
+            this.Size = new System.Drawing.Size(2, 64);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label HorLine;
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    public partial class HorizontalLineControl : UserControl, IControlInterface
+    {
+        public HorizontalLineControl()
+        {
+            InitializeComponent();
+        }
+
+        public string FieldName
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string ValueName
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool NullValue
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IfNecesseryFullfiled()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.resx
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/HorizontalLineControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/IControlInterface.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/IControlInterface.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    interface IControlInterface
+    {
+        string FieldName
+        {
+            get;
+            set;
+        }
+        string ValueName { get; set; }
+        bool NullValue
+        {
+            get;
+            set;
+        }
+        bool IfNecesseryFullfiled();
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.Designer.cs
@@ -1,0 +1,79 @@
+﻿namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    partial class OneColumnDropDownEditor
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.ColumnNameTextBox = new System.Windows.Forms.TextBox();
+            this.ValueDropDownList = new System.Windows.Forms.ComboBox();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // ColumnNameTextBox
+            // 
+            this.ColumnNameTextBox.Location = new System.Drawing.Point(0, 0);
+            this.ColumnNameTextBox.Multiline = true;
+            this.ColumnNameTextBox.Name = "ColumnNameTextBox";
+            this.ColumnNameTextBox.ReadOnly = true;
+            this.ColumnNameTextBox.Size = new System.Drawing.Size(121, 38);
+            this.ColumnNameTextBox.TabIndex = 2;
+            // 
+            // ValueDropDownList
+            // 
+            this.ValueDropDownList.FormattingEnabled = true;
+            this.ValueDropDownList.Location = new System.Drawing.Point(0, 44);
+            this.ValueDropDownList.Name = "ValueDropDownList";
+            this.ValueDropDownList.Size = new System.Drawing.Size(121, 21);
+            this.ValueDropDownList.TabIndex = 3;
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // OneColumnDropDownEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.ValueDropDownList);
+            this.Controls.Add(this.ColumnNameTextBox);
+            this.Name = "OneColumnDropDownEditor";
+            this.Size = new System.Drawing.Size(121, 64);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox ColumnNameTextBox;
+        private System.Windows.Forms.ComboBox ValueDropDownList;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    public partial class OneColumnDropDownEditor : UserControl, IControlInterface
+    {
+        public OneColumnDropDownEditor()
+        {
+            InitializeComponent();
+        }
+
+        public void SelectItem()
+        {
+            ValueDropDownList.SelectedIndex = 0;
+        }
+        public void SelectItem(string name)
+        {
+            ValueDropDownList.SelectedItem = name;
+        }
+
+        public string ValueName
+        {
+            get
+            {
+                return ValueDropDownList.SelectedItem.ToString();
+            }
+            set
+            {
+                 ValueDropDownList.SelectedItem = value;
+            }
+        }
+
+
+        public string FieldName
+        {
+            get
+            {
+                return ColumnNameTextBox.Text.TrimEnd('*');
+            }
+            set
+            {
+                ColumnNameTextBox.Text = value;
+            }
+        }
+
+        public bool NullValue { get; set; }
+
+        public string Type { get; set; }
+
+        public string[] Values
+        {
+            get
+            {
+                string[] tmpArray = new string[ValueDropDownList.Items.Count];
+                for(int i = 0;i<ValueDropDownList.Items.Count;i++)
+                    tmpArray[i] = ValueDropDownList.Items[i].ToString();
+                return tmpArray;
+            }
+            set
+            {
+                if (NullValue)
+                    ValueDropDownList.Items.Add("NULL");
+                foreach (string item in value)
+                    ValueDropDownList.Items.Add(item);
+            }
+        }
+
+        public bool IfNecesseryFullfiled()
+        {
+            errorProvider1.Clear();
+            if (!NullValue)
+                if (ValueDropDownList.SelectedItem.ToString() != "")
+                {
+                    errorProvider1.SetError(this, "This column has to have value");
+                    return false;
+                }
+            return true;
+        }
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.resx
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnDropDownEditor.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.Designer.cs
@@ -1,0 +1,78 @@
+﻿namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    partial class OneColumnTextEditor
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.ValueTextBox = new System.Windows.Forms.TextBox();
+            this.FieldNameTextBox = new System.Windows.Forms.TextBox();
+            this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // ValueTextBox
+            // 
+            this.ValueTextBox.Location = new System.Drawing.Point(0, 44);
+            this.ValueTextBox.Name = "ValueTextBox";
+            this.ValueTextBox.Size = new System.Drawing.Size(121, 20);
+            this.ValueTextBox.TabIndex = 0;
+            // 
+            // FieldNameTextBox
+            // 
+            this.FieldNameTextBox.Location = new System.Drawing.Point(0, 0);
+            this.FieldNameTextBox.Multiline = true;
+            this.FieldNameTextBox.Name = "FieldNameTextBox";
+            this.FieldNameTextBox.ReadOnly = true;
+            this.FieldNameTextBox.Size = new System.Drawing.Size(121, 38);
+            this.FieldNameTextBox.TabIndex = 3;
+            // 
+            // errorProvider1
+            // 
+            this.errorProvider1.ContainerControl = this;
+            // 
+            // OneColumnTextEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.FieldNameTextBox);
+            this.Controls.Add(this.ValueTextBox);
+            this.Name = "OneColumnTextEditor";
+            this.Size = new System.Drawing.Size(124, 67);
+            ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox ValueTextBox;
+        private System.Windows.Forms.TextBox FieldNameTextBox;
+        private System.Windows.Forms.ErrorProvider errorProvider1;
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DB_Editor.Components.MainWindow.States.RowEditor.Partials
+{
+    public partial class OneColumnTextEditor : UserControl, IControlInterface
+    {
+        public OneColumnTextEditor()
+        {
+            InitializeComponent();
+
+        }
+
+        public string FieldName
+        {
+            get
+            {
+                return FieldNameTextBox.Lines[0].TrimEnd('*');
+            }
+            set
+            {
+                FieldNameTextBox.Text = value;
+            }
+        }
+
+        public string ValueName
+        {
+            get
+            {
+                return ValueTextBox.Text;
+            }
+            set
+            {
+                ValueTextBox.Text = value;
+            }
+        }
+
+        public bool NullValue { get; set; }
+
+        public string Type 
+        { 
+            get
+            {
+                return FieldNameTextBox.Lines[1];
+            }
+            set
+            {
+                FieldNameTextBox.Text += System.Environment.NewLine + value;
+            }
+        }
+
+        public int Length
+        {
+            get
+            {
+                return ValueTextBox.MaxLength;
+            }
+            set
+            {
+                ValueTextBox.MaxLength = value;
+            }
+        }
+
+        public bool IfNecesseryFullfiled()
+        {
+            errorProvider1.Clear();
+            if (!NullValue)
+                if (ValueTextBox.Text != "")
+                {
+                    errorProvider1.SetError(this, "This column has to have value");
+                    return false;
+                }
+            return true;
+        }
+    }
+}

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.resx
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/Partials/OneColumnTextEditor.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditor.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditor.cs
@@ -20,11 +20,12 @@ namespace DB_Editor.Components.MainWindow.States.RowEditor
 
             control_ = Control as RowEditorControl;
             control_.SetTitle = SetTitle;
+            AllowChangeState = true;
         }
 
         public void SetTitle(string tableName)
         {
-            Title = string.Format("Editing record of \"{0}\" table", tableName);
+            Title = string.Format("Adding record of \"{0}\" table", tableName);
         }
 
         public override void OnNextState()

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditorControl.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditorControl.Designer.cs
@@ -28,7 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.container = new System.Windows.Forms.FlowLayoutPanel();
+            this.RowEditorContainer = new System.Windows.Forms.FlowLayoutPanel();
+            this.SuspendLayout();
+            // 
+            // RowEditorContainer
+            // 
+            this.RowEditorContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RowEditorContainer.Location = new System.Drawing.Point(0, 0);
+            this.RowEditorContainer.Name = "RowEditorContainer";
+            this.RowEditorContainer.Size = new System.Drawing.Size(476, 308);
+            this.RowEditorContainer.TabIndex = 0;
+            // 
+            // RowEditorControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.RowEditorContainer);
+            this.Name = "RowEditorControl";
+            this.Size = new System.Drawing.Size(476, 308);
+            this.RowEditorContainer.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+
+            /*this.container = new System.Windows.Forms.FlowLayoutPanel();
             this.SuspendLayout();
             // 
             // container
@@ -46,12 +68,12 @@
             this.Controls.Add(this.container);
             this.Name = "RowEditorControl";
             this.Size = new System.Drawing.Size(476, 308);
-            this.ResumeLayout(false);
+            this.ResumeLayout(false);*/
 
         }
 
         #endregion
 
-        private System.Windows.Forms.FlowLayoutPanel container;
+        private System.Windows.Forms.FlowLayoutPanel RowEditorContainer;
     }
 }

--- a/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditorControl.cs
+++ b/src/DB-Editor/Components/MainWindow/States/RowEditor/RowEditorControl.cs
@@ -10,18 +10,28 @@ using System.Windows.Forms;
 using DB_Editor.Events;
 using DB_Editor.Components.MainWindow.Definitions;
 using DB_Editor.Components.MainWindow.States.RowEditor.Partials;
+using DB_Editor.DB_Handlers;
 
 namespace DB_Editor.Components.MainWindow.States.RowEditor
 {
     public partial class RowEditorControl : StateControl
     {
-        private Dictionary<string, string> oldValues_ = new Dictionary<string,string>();
+        private Dictionary<string, string> oldValues_ = new Dictionary<string, string>();
 
         private Dictionary<string, FieldEditor> fieldEditors_ = new Dictionary<string, FieldEditor>();
+        private HorizontalLineControl tmpCtrl_ = new HorizontalLineControl();
+        private bool ChangeRowControl_;
+
 
         public RowEditorControl()
         {
             InitializeComponent();
+            RowEditorContainer.Controls.Clear();
+        }
+
+        public void AddControl(Control ctrl)
+        {
+            RowEditorContainer.Controls.Add(ctrl);
         }
 
         public string TableName { get; set; }
@@ -34,22 +44,129 @@ namespace DB_Editor.Components.MainWindow.States.RowEditor
             {
                 TableName = value.Data["tableName"];
                 SetTitle(TableName);
-                ReadRecordDataOnStateChange(value.Data);
-                BuildFields();
+                if (value.Data["changeRow"] == "changeRow")
+                {
+                    ReadRecordDataOnStateChange(value.Data);
+                    BuildFields();
+                    ChangeRowControl_ = true;
+                }
+                else
+                {
+                    MakeAllTheComponents();
+                    ChangeRowControl_ = false;
+                }
+
             }
         }
 
-        public void Save()
+        private void MakeAllTheComponents()
         {
-            try
+            List<ColumnStructureCreator> tmpList = new List<ColumnStructureCreator>();
+            tmpList = Database.GetColumnStructureCreatorsFromTable(TableName);
+            foreach (ColumnStructureCreator item in tmpList)
             {
-                DB_Handlers.Record.ChangeRowValue(TableName, oldValues_, GetChangedFields());
-            }
-            catch(Exception e)
-            {
-                DisplayError.FireDisplayErrorEvent(e.Message);
+                OneColumnDropDownEditor example1 = new OneColumnDropDownEditor();
+                OneColumnTextEditor example2 = new OneColumnTextEditor();
+                if (item.Type == "enum")
+                {
+                    example1.FieldName = item.Field;
+                    string[] tmpList2 = DB_Handlers.Table.GetEnumValues(TableName, item.Field);
+
+                    example1.Values = tmpList2;
+                    example1.NullValue = item.NullValue;
+                    if (!item.NullValue)
+                    {
+
+                        example1.FieldName = example1.FieldName + "*";
+                        example1.SelectItem();
+                    }
+                    example1.Type = "enum";
+                    if (item.Default != "")
+                        example1.SelectItem(item.Default);
+                    example1.Show();
+                    this.RowEditorContainer.Controls.Add(example1);
+                }
+                else
+                {
+                    example2.FieldName = item.Field;
+                    //example2.NullValue = item.NullValue;
+                    if (!item.NullValue)
+                    {
+                        example2.FieldName = example2.FieldName + "*";
+                    }
+
+                    example2.Type = item.Type;
+                    example2.ValueName = item.Default;
+                    example2.Show();
+                    this.RowEditorContainer.Controls.Add(example2);
+                }
+                this.RowEditorContainer.Controls.Add(new HorizontalLineControl());
             }
         }
+
+        private bool IsItAllowed()
+        {
+            bool result = false;
+            foreach (IControlInterface item in RowEditorContainer.Controls)
+            {
+                if (item.GetType() != tmpCtrl_.GetType())
+                {
+                    if (item.IfNecesseryFullfiled())
+                        result = true;
+                    else
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+
+        public void Save()
+        {
+            if (ChangeRowControl_)
+            {
+                try
+                {
+                    DB_Handlers.Record.ChangeRowValue(TableName, oldValues_, GetChangedFields());
+                }
+                catch (Exception e)
+                {
+                    DisplayError.FireDisplayErrorEvent(e.Message);
+                }
+            }
+            else
+            {
+                try
+                {
+                    List<string> columnNames = new List<string>();
+                    List<string> values = new List<string>();
+                    foreach (IControlInterface item in RowEditorContainer.Controls)
+                    {
+                        if (item.GetType() != tmpCtrl_.GetType())
+                        {
+                            if (item.FieldName != "")
+                                columnNames.Add(item.FieldName);
+                            else
+                                columnNames.Add("NULL");
+                            if (item.ValueName != "")
+                                values.Add(item.ValueName);
+                            else
+                                values.Add("NULL");
+                        }
+                    }
+                    DB_Handlers.Record.InsertRowValue(TableName, columnNames, values);
+                }
+                catch (Exception e)
+                {
+                    DisplayError.FireDisplayErrorEvent(e.Message);
+                }
+            }
+        }
+
+
 
         private void BuildFields()
         {
@@ -63,8 +180,9 @@ namespace DB_Editor.Components.MainWindow.States.RowEditor
                         fieldEditor.FieldName = fieldData.Key;
                         fieldEditor.Value = fieldData.Value;
                         fieldEditor.FieldType = DB_Handlers.Table.GetFieldDataType(fieldData.Key, TableName);
+                        //linijka wyzej powoduje blad, ktory wyskakuje przy probie edycji jakiego rekordu
                         fieldEditor.Show();
-                        container.Controls.Add(fieldEditor);
+                        RowEditorContainer.Controls.Add(fieldEditor);
                         fieldEditors_.Add(fieldData.Key, fieldEditor);
                     }
                     catch (Exception e)
@@ -92,6 +210,7 @@ namespace DB_Editor.Components.MainWindow.States.RowEditor
 
             foreach (var oldValue in oldValues_)
             {
+                //linijka nizej, najprawdopodobniej szukasz po "zlym" kluczu, przez to nie chce sie zapisywac zmiana
                 if (oldValue.Value != fieldEditors_[oldValue.Key].Value)
                 {
                     FieldEditor fieldEditor = fieldEditors_[oldValue.Key];

--- a/src/DB-Editor/Components/MainWindow/States/TableEditor/Partials/FieldEditor.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/States/TableEditor/Partials/FieldEditor.Designer.cs
@@ -85,7 +85,7 @@
             // 
             this.LengthLabel.AutoSize = true;
             this.LengthLabel.Font = new System.Drawing.Font("Calibri Light", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.LengthLabel.Location = new System.Drawing.Point(211, 9);
+            this.LengthLabel.Location = new System.Drawing.Point(222, 9);
             this.LengthLabel.Name = "LengthLabel";
             this.LengthLabel.Size = new System.Drawing.Size(42, 15);
             this.LengthLabel.TabIndex = 6;
@@ -97,13 +97,16 @@
             this.LengthTxtBox.Location = new System.Drawing.Point(211, 27);
             this.LengthTxtBox.Name = "LengthTxtBox";
             this.LengthTxtBox.ReadOnly = true;
-            this.LengthTxtBox.Size = new System.Drawing.Size(42, 22);
+            this.LengthTxtBox.Size = new System.Drawing.Size(71, 22);
             this.LengthTxtBox.TabIndex = 5;
+            this.LengthTxtBox.Click += new System.EventHandler(this.LengthTxtBox_Click);
+            this.LengthTxtBox.Leave += new System.EventHandler(this.LengthTxtBox_Leave);
+            this.LengthTxtBox.MouseHover += new System.EventHandler(this.LengthTxtBox_MouseHover);
             // 
             // NullDrpDwnLst
             // 
             this.NullDrpDwnLst.FormattingEnabled = true;
-            this.NullDrpDwnLst.Location = new System.Drawing.Point(264, 27);
+            this.NullDrpDwnLst.Location = new System.Drawing.Point(288, 27);
             this.NullDrpDwnLst.Name = "NullDrpDwnLst";
             this.NullDrpDwnLst.Size = new System.Drawing.Size(55, 21);
             this.NullDrpDwnLst.TabIndex = 8;
@@ -112,7 +115,7 @@
             // 
             this.NullLabel.AutoSize = true;
             this.NullLabel.Font = new System.Drawing.Font("Calibri Light", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.NullLabel.Location = new System.Drawing.Point(277, 9);
+            this.NullLabel.Location = new System.Drawing.Point(298, 8);
             this.NullLabel.Name = "NullLabel";
             this.NullLabel.Size = new System.Drawing.Size(28, 15);
             this.NullLabel.TabIndex = 7;
@@ -162,7 +165,7 @@
             this.DeleteButton.BackColor = System.Drawing.Color.Crimson;
             this.DeleteButton.Font = new System.Drawing.Font("Calibri Light", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.DeleteButton.ForeColor = System.Drawing.Color.White;
-            this.DeleteButton.Location = new System.Drawing.Point(410, 17);
+            this.DeleteButton.Location = new System.Drawing.Point(434, 18);
             this.DeleteButton.Name = "DeleteButton";
             this.DeleteButton.Size = new System.Drawing.Size(62, 40);
             this.DeleteButton.TabIndex = 12;
@@ -172,7 +175,7 @@
             // 
             // defaultTextBox
             // 
-            this.defaultTextBox.Location = new System.Drawing.Point(325, 27);
+            this.defaultTextBox.Location = new System.Drawing.Point(349, 27);
             this.defaultTextBox.Name = "defaultTextBox";
             this.defaultTextBox.Size = new System.Drawing.Size(79, 20);
             this.defaultTextBox.TabIndex = 13;
@@ -181,7 +184,7 @@
             // 
             this.defaultLabel.AutoSize = true;
             this.defaultLabel.Font = new System.Drawing.Font("Calibri Light", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.defaultLabel.Location = new System.Drawing.Point(346, 9);
+            this.defaultLabel.Location = new System.Drawing.Point(362, 8);
             this.defaultLabel.Name = "defaultLabel";
             this.defaultLabel.Size = new System.Drawing.Size(45, 15);
             this.defaultLabel.TabIndex = 14;
@@ -209,7 +212,7 @@
             this.Margin = new System.Windows.Forms.Padding(3, 3, 3, 15);
             this.Name = "FieldEditor";
             this.Padding = new System.Windows.Forms.Padding(10);
-            this.Size = new System.Drawing.Size(490, 86);
+            this.Size = new System.Drawing.Size(512, 86);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/DB-Editor/Components/MainWindow/States/TableEditor/Partials/FieldEditor.cs
+++ b/src/DB-Editor/Components/MainWindow/States/TableEditor/Partials/FieldEditor.cs
@@ -15,9 +15,10 @@ namespace DB_Editor.Components.MainWindow.States.TableEditor.Partials
     public partial class FieldEditor : UserControl
     {
         private FieldEditorPresenter presenter_;
-        private static bool auto_increment_clicked;
-        private static bool primary_key_clicked;
-        private static bool foreign_key_clicked;
+        private bool auto_increment_clicked;
+        private bool primary_key_clicked;
+        private bool foreign_key_clicked;
+        private ToolTip tltip_;
 
         public FieldEditor()
         {
@@ -29,6 +30,8 @@ namespace DB_Editor.Components.MainWindow.States.TableEditor.Partials
             foreign_key_clicked = false;
             TableNameItBelongs = "";
             EditorTableMode = false;
+            tltip_ = new ToolTip();
+            tltip_.Active = false;
         }
 
         #region Properties
@@ -239,9 +242,26 @@ namespace DB_Editor.Components.MainWindow.States.TableEditor.Partials
         {
             string[] settingableTypes = new string[] { "float", "double", "decimal", "char", "varchar", "text", "enum" };
             if (settingableTypes.Contains(fieldTypeDrpDwnLst.SelectedItem))
+            {
+                LengthTxtBox.ForeColor = Color.Silver;
+                if (fieldTypeDrpDwnLst.SelectedItem == "enum")
+                {
+
+                    LengthTxtBox.Text = "first_poss, second_poss, third_poss";
+                }
+                else
+                {
+                    LengthTxtBox.Text = "20";
+                }
                 LengthReadOnly = false;
+                tltip_.Active = true;
+            }
             else
+            {
+                LengthTxtBox.Text = "";
                 LengthReadOnly = true;
+                tltip_.Active = false;
+            }
         }
 
         private void DeleteButton_Click(object sender, EventArgs e)
@@ -256,6 +276,29 @@ namespace DB_Editor.Components.MainWindow.States.TableEditor.Partials
             }
             else
                 this.Dispose();
+        }
+        #endregion
+
+        #region HandlingHelpingWithTypeLengthChoice
+        private void LengthTxtBox_MouseHover(object sender, EventArgs e)
+        {
+            if (FieldType == "enum")
+                tltip_.SetToolTip(LengthTxtBox, "Insert possibilities one after another adding comma between \n for example: \n first_poss, second_poss, third_poss");
+            else
+                tltip_.SetToolTip(LengthTxtBox, "Insert maximum size of this type of data \n(for example \"20\").");
+        }
+        private void LengthTxtBox_Click(object sender, EventArgs e)
+        {
+            if (LengthTxtBox.Text == "20" || LengthTxtBox.Text == "first_poss, second_poss, third_poss")
+                LengthTxtBox.Text = "";
+            LengthTxtBox.ForeColor = Color.Black;
+        }
+        private void LengthTxtBox_Leave(object sender, EventArgs e)
+        {
+            if (LengthTxtBox.Text == "")
+            {
+                Field_Type_Changed(new object(), new EventArgs());
+            }
         }
         #endregion
     }

--- a/src/DB-Editor/Components/MainWindow/View.Designer.cs
+++ b/src/DB-Editor/Components/MainWindow/View.Designer.cs
@@ -29,13 +29,13 @@
         private void InitializeComponent()
         {
             this.splitContainer = new System.Windows.Forms.SplitContainer();
+            this.databasesList = new DB_Editor.Components.MainWindow.Partials.DatabasesListView();
             this.buttonsContainer = new System.Windows.Forms.Panel();
             this.buttonBack = new System.Windows.Forms.Button();
             this.buttonNext = new System.Windows.Forms.Button();
             this.RightPanelTitle = new System.Windows.Forms.Label();
             this.rightPanelWrapper = new System.Windows.Forms.Panel();
             this.rightPanel = new System.Windows.Forms.FlowLayoutPanel();
-            this.databasesList = new DB_Editor.Components.MainWindow.Partials.DatabasesListView();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.Panel2.SuspendLayout();
@@ -68,6 +68,16 @@
             this.splitContainer.SplitterDistance = 269;
             this.splitContainer.SplitterWidth = 1;
             this.splitContainer.TabIndex = 0;
+            // 
+            // databasesList
+            // 
+            this.databasesList.AutoSize = true;
+            this.databasesList.AutoValidate = System.Windows.Forms.AutoValidate.EnablePreventFocusChange;
+            this.databasesList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.databasesList.Location = new System.Drawing.Point(15, 15);
+            this.databasesList.Name = "databasesList";
+            this.databasesList.Size = new System.Drawing.Size(239, 531);
+            this.databasesList.TabIndex = 0;
             // 
             // buttonsContainer
             // 
@@ -143,16 +153,6 @@
             this.rightPanel.Name = "rightPanel";
             this.rightPanel.Size = new System.Drawing.Size(554, 396);
             this.rightPanel.TabIndex = 4;
-            // 
-            // databasesList
-            // 
-            this.databasesList.AutoSize = true;
-            this.databasesList.AutoValidate = System.Windows.Forms.AutoValidate.EnablePreventFocusChange;
-            this.databasesList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.databasesList.Location = new System.Drawing.Point(15, 15);
-            this.databasesList.Name = "databasesList";
-            this.databasesList.Size = new System.Drawing.Size(239, 531);
-            this.databasesList.TabIndex = 0;
             // 
             // View
             // 

--- a/src/DB-Editor/Components/MainWindow/View.cs
+++ b/src/DB-Editor/Components/MainWindow/View.cs
@@ -64,6 +64,7 @@ namespace DB_Editor.Components.MainWindow
                 if (presenter_.ActiveState.DefaultNextStateData != null)
                 {
                     args.Data = presenter_.ActiveState.DefaultNextStateData;
+                    args.Data["changeRow"] = "anythingElse";
                 }
 
                 StateChangeRequestEvents.FireStateChangeRequest(sender, args);

--- a/src/DB-Editor/DB-Editor.csproj
+++ b/src/DB-Editor/DB-Editor.csproj
@@ -110,6 +110,25 @@
     <Compile Include="Components\MainWindow\States\RowEditor\Partials\FieldEditor.Designer.cs">
       <DependentUpon>FieldEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\HorizontalLineControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\HorizontalLineControl.designer.cs">
+      <DependentUpon>HorizontalLineControl.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\IControlInterface.cs" />
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\OneColumnDropDownEditor.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\OneColumnDropDownEditor.designer.cs">
+      <DependentUpon>OneColumnDropDownEditor.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\OneColumnTextEditor.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Components\MainWindow\States\RowEditor\Partials\OneColumnTextEditor.designer.cs">
+      <DependentUpon>OneColumnTextEditor.cs</DependentUpon>
+    </Compile>
     <Compile Include="Components\MainWindow\States\RowEditor\RowEditor.cs" />
     <Compile Include="Components\MainWindow\States\RowEditor\RowEditorControl.cs">
       <SubType>UserControl</SubType>
@@ -191,6 +210,15 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Components\MainWindow\States\RowEditor\Partials\FieldEditor.resx">
       <DependentUpon>FieldEditor.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Components\MainWindow\States\RowEditor\Partials\HorizontalLineControl.resx">
+      <DependentUpon>HorizontalLineControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Components\MainWindow\States\RowEditor\Partials\OneColumnDropDownEditor.resx">
+      <DependentUpon>OneColumnDropDownEditor.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Components\MainWindow\States\RowEditor\Partials\OneColumnTextEditor.resx">
+      <DependentUpon>OneColumnTextEditor.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Components\MainWindow\States\RowEditor\RowEditorControl.resx">
       <DependentUpon>RowEditorControl.cs</DependentUpon>

--- a/src/DB-Editor/DB-Handlers/ColumnStructureCreator.cs
+++ b/src/DB-Editor/DB-Handlers/ColumnStructureCreator.cs
@@ -47,21 +47,35 @@ namespace DB_Editor.DB_Handlers
             string primaryKeyString = "";
             string extraString = "";
             if (TypeLength != "")
-                Type += " " + TypeLength;
+            {
+                Type += "(";
+                if (TypeLength.Any(char.IsDigit))
+                    Type += TypeLength;
+                else
+                {
+                    string[] tmpArray = TypeLength.Split(',');
+                    foreach (string str in tmpArray)
+                    {
+                        Type += "'" + str.Trim() + "', ";
+                    }
+                    Type = Type.Substring(0, Type.Length - 2);
+                }
+                Type += ") ";
+            }
             string tmp = "";
             if (!NullValue)
-                nullValueString = "NOT NULL";
+                nullValueString = "NOT NULL ";
             if (Primary_Key)
-                primaryKeyString = "PRIMARY KEY";
+                primaryKeyString = " PRIMARY KEY";
             if (Extra)
                 extraString = "auto_increment";
             if (Default != String.Empty)
             {
                 Default = "DEFAULT \"" + Default + "\"";
-                tmp = Field + " " + Type + " " + nullValueString + " " + Default + " " + extraString + " " + primaryKeyString;
+                tmp = Field + " " + Type + nullValueString + Default + " " + extraString + primaryKeyString;
             }
             else
-                tmp = Field + " " + Type + " " + nullValueString + " " + extraString + " " + primaryKeyString;
+                tmp = Field + " " + Type + nullValueString + extraString + primaryKeyString;
             return tmp.TrimEnd();
         }     
         public static bool operator ==(ColumnStructureCreator firstColumn, ColumnStructureCreator secondColumn)

--- a/src/DB-Editor/DB-Handlers/Database.cs
+++ b/src/DB-Editor/DB-Handlers/Database.cs
@@ -289,7 +289,10 @@ namespace DB_Editor.DB_Handlers
                                 {
                                     tmpStrings = reader[i].ToString().Split(delimiterChar);
                                     tmps.Type = tmpStrings[0];
-                                    tmps.TypeLength = tmpStrings[1].TrimEnd(')');
+                                    if (tmpStrings.Length > 1)
+                                    {
+                                        tmps.TypeLength = tmpStrings[1].TrimEnd(')');
+                                    }
                                 }
                                 break;
                             case "Null":

--- a/src/DB-Editor/DB-Handlers/Record.cs
+++ b/src/DB-Editor/DB-Handlers/Record.cs
@@ -79,7 +79,7 @@ namespace DB_Editor.DB_Handlers
         //oko.Add(ok2);
         //oko.Add(ok3);
         //Record.InsertRowValue("stringtable", ok2, oko, "ok");
-        public static OperationResult InsertRowValue(string tableName, string[] ColumnNames, List<string[]> Values)
+        public static OperationResult InsertRowValue(string tableName, List<string> ColumnNames, List<string> Values)
         {
             try
             {
@@ -91,20 +91,17 @@ namespace DB_Editor.DB_Handlers
                 foreach (string columnName in ColumnNames)
                     tmp += columnName + ", ";
                 tmp = tmp.Substring(0, tmp.Length - 2);
-                tmp += ") VALUES ";
+                tmp += ") VALUES (";
 
-                foreach (var stringArrays in Values)
+                foreach (string value in Values)
                 {
-                    tmp += "(";
-                    foreach (var stringArray in stringArrays)
-                    {
-                        tmp += "\"" + stringArray + "\", ";
-                    }
-                    tmp = tmp.Substring(0, tmp.Length - 2);
-                    tmp += "), ";
+                    if (value == "NULL")
+                        tmp += value + ", ";
+                    else
+                        tmp += "\"" + value + "\", ";
                 }
                 tmp = tmp.Substring(0, tmp.Length - 2);
-                tmp += ";";
+                tmp += ");";
 
                 MySqlCommand command_ = new MySqlCommand(tmp, DBConnectionManager.Connection);
                 command_.ExecuteNonQuery();
@@ -159,7 +156,10 @@ namespace DB_Editor.DB_Handlers
                 tmp += "DELETE FROM " + dbName_ + tableName + " WHERE ";
                 foreach(var item in pairs)
                 {
-                    tmp += item.Key + " = \"" + item.Value + "\" AND ";
+                    if(item.Value == "")
+                        tmp += item.Key + " IS NULL AND ";
+                    else
+                        tmp += item.Key + " = \"" + item.Value + "\" AND ";
                 }
                 tmp = tmp.Substring(0, tmp.Length - 5);
                 tmp += ";";

--- a/src/DB-Editor/DB-Handlers/Table.cs
+++ b/src/DB-Editor/DB-Handlers/Table.cs
@@ -46,7 +46,7 @@ namespace DB_Editor.DB_Handlers
         {
             try
             {
-                dbName_ = DB_Connection.DBConnectionManager.DatabaseName;
+                //dbName_ = DB_Connection.DBConnectionManager.DatabaseName;
                 DBConnectionManager.Connection.Open();
                 CheckDbName(ref dbName);
                 command_.CommandText = "ALTER TABLE " + dbName + tableName + " CHANGE " + oldColumnName + " " + newColumn.ToString() + ";";
@@ -321,6 +321,38 @@ namespace DB_Editor.DB_Handlers
                 DBConnectionManager.Connection.Close();
             }
         }
+        public static string[] GetEnumValues(string tableName, string columnName)
+        {
+            try
+            {
+                DB_Connection.DBConnectionManager.Connection.Open();
+                string tmp = "SELECT column_type FROM information_schema.columns where table_schema = '";
+                tmp += DB_Connection.DBConnectionManager.DatabaseName;
+                tmp += "' and table_name = '" + tableName + "' and column_name = '" + columnName + "';";
+                command_ = new MySqlCommand(tmp, DB_Connection.DBConnectionManager.Connection);
+
+                MySqlDataReader reader = command_.ExecuteReader();
+                reader.Read();
+                tmp = reader.GetString(0);
+                tmp = tmp.Remove(0, 6);
+                tmp = tmp.Substring(0, tmp.Length - 2);
+                string[] tmpArray = tmp.Split(',');
+
+                for (int i = 0; i < tmpArray.Length; i++)
+                    tmpArray[i] = tmpArray[i].Trim('\'');
+
+                return tmpArray;
+            }
+            catch (Exception e)
+            {
+                throw new System.Exception(e.Message);
+            }
+            finally
+            {
+                DBConnectionManager.Connection.Close();
+            }
+        }
+        
         #endregion
 
         #region PrivateMethods


### PR DESCRIPTION
Poprawiono metode tworzaca liste kolumn z wlasciwosciami.
Zaimplementowano mechanizm wyswietlania wszystkich kolumn wraz z koniecznym polem do pisania/zaznaczenia.
Zaimplementowano mechanizm dodawania nowych rekordow.
Poprawiono metode ToString() dla ColumnStrctureCreator
Poprawa pol statycznych na normalne reprezentujace klikniecie w primarykey/foreignkey/autoincrement.
Zmiana typu danych z edytowalnej dlguosci na nieedytowalna czysci pole do dlugosci tekstu.
Dodano pomocnicze dlugosci danych dla wybranych typow dnaych (zarowno dymki jak i przykladowe dane w textboxie, ktore odpowiednio znikaja i pojawiaja sie)
Poprawiono blad, ktory nie usuwal rekordow z pustymi wartosciami
Poprawiono wyglad kontrolki FieldEditor
